### PR TITLE
Move filtering logic from Projects.razor to ViewModel 

### DIFF
--- a/src/Pages/Projects.razor
+++ b/src/Pages/Projects.razor
@@ -8,14 +8,14 @@
     <h2>Projects</h2>
     
     <h4>Filter by</h4>
-      <EditForm Model="@keyWords" OnValidSubmit="@HandleValidSubmit">
+      <EditForm Model="@_resumeViewModel.keyWords" OnValidSubmit="@HandleValidSubmit">
         <DataAnnotationsValidator />
         <ValidationSummary />
         <div class="row">
             <div class="col">
                 <div class="form-group">
                     <label for="domain">Domain</label>
-                    <InputSelect id="domain" class="form-control-dropdown-filter" @bind-Value="@keyWords.selectedDomain">
+                    <InputSelect id="domain" class="form-control-dropdown-filter" @bind-Value="@_resumeViewModel.keyWords.selectedDomain">
                         <option value="">All</option>
                         @foreach (var domain in domains)
                         {
@@ -27,16 +27,16 @@
             <div class="col">
                 <div class="form-group">
                     <label for="condition">and/or</label>
-                    <InputSelect id="condition" class="form-control-dropdown-filter" @bind-Value="@keyWords.condition">
-                        <option value="or">or</option>
+                    <InputSelect id="condition" class="form-control-dropdown-filter" @bind-Value="@_resumeViewModel.keyWords.condition">
                         <option value="and">and</option>
+                        <option value="or">or</option>
                     </InputSelect>
                 </div>
             </div>
             <div class="col">
                 <div class="form-group">
                     <label for="techStack">Tech Stack</label>
-                    <InputSelect id="techStack" class="form-control-dropdown-filter" @bind-Value="@keyWords.selectedTechStack">
+                    <InputSelect id="techStack" class="form-control-dropdown-filter" @bind-Value="@_resumeViewModel.keyWords.selectedTechStack">
                         <option value="">All</option>
                         @foreach (var techStack in techStacks)
                         {
@@ -55,36 +55,9 @@
 
     @if (_resumeViewModel != null && _resumeViewModel.Projects != null)
     {
-      foreach (var projectModel in _resumeViewModel.Projects)
+      foreach (var projectModel in filteredProjects)
       {
-        @* Console.WriteLine($"Project: {projectModel.Title}"); *@
-        List<string> keyWords = projectModel?.KeyWords?.Split(',').ToList() ?? new List<string>();
-        // Apply left strip to all keyWords
-        keyWords = keyWords.Select(keyWord => keyWord.TrimStart()).ToList();
-        // If no filters are selected, display all projects
-        if (string.IsNullOrEmpty(selectedDomain) && string.IsNullOrEmpty(selectedTechStack))
-        {
-            <ProjectCard data=@projectModel></ProjectCard>
-        }
-        // If the project matches the selected domain or tech stack, display it
-        else if ((condition == "or") && ((selectedDomain != "" && keyWords.Contains(selectedDomain))
-                || (selectedTechStack != "" && keyWords.Contains(selectedTechStack))))
-        {
-            <ProjectCard data=@projectModel></ProjectCard>
-        }
-        // If the project matches the selected domain and tech stack, display it
-        else if ((condition == "and") && ((selectedDomain != "" && keyWords.Contains(selectedDomain))
-                && (selectedTechStack != "" && keyWords.Contains(selectedTechStack))))
-        {
-            <ProjectCard data=@projectModel></ProjectCard>
-        }
-        else
-        {
-          @* Console.WriteLine("No projects to display");
-          Console.WriteLine($"Domain: {selectedDomain}");
-          Console.WriteLine($"Tech Stack: {selectedTechStack}");
-          keyWords.ForEach(keyWord => Console.WriteLine(keyWord)); *@
-        }
+        <ProjectCard data=@projectModel></ProjectCard>
       }
     }
     else
@@ -98,24 +71,30 @@
 </div>
 
 @code {
-    private KeyWords keyWords = new KeyWords();
+    private List<ProjectModel> filteredProjects = new List<ProjectModel>();
     private string condition { get; set; } = "or";
     private string selectedDomain { get; set; } = "";
     private string selectedTechStack { get; set; } = "";
     List<string> domains = new List<string> { "AI", "IoT", "Web", "Robotics", "Cloud", "Data Science", "DevOps" };
     List<string> techStacks = new List<string> { "Python", "C#", "C++", "Bash", ".NET", "Blazor", "Flask", "TensorFlow", "Folium", "MicroPython", "Microsoft Azure", "DigitalOcean", "Terraform", "Matplotlib", "OpenGL" , "Windows Forms", "Docker", "GitHub Actions", "Prometheus", "Grafana" };
 
-    protected override async Task OnInitializedAsync() => await _resumeViewModel.GetProjects();
+    protected override async Task OnInitializedAsync()
+    {
+        await _resumeViewModel.GetProjects();
+        filteredProjects = _resumeViewModel.FilterProjects(selectedDomain, selectedTechStack, condition);
+    }
 
     private void HandleValidSubmit()
     {
         // Do something with the selected values
-        Console.WriteLine($"Selected condition: {keyWords.condition}");
-        Console.WriteLine($"Selected domain: {keyWords.selectedDomain}");
-        Console.WriteLine($"Selected tech stack: {keyWords.selectedTechStack}");
-        condition = keyWords?.condition ?? "or";
-        selectedDomain = keyWords?.selectedDomain ?? "";
-        selectedTechStack = keyWords?.selectedTechStack ?? "";
+        Console.WriteLine($"Selected condition: {_resumeViewModel.keyWords.condition}");
+        Console.WriteLine($"Selected domain: {_resumeViewModel.keyWords.selectedDomain}");
+        Console.WriteLine($"Selected tech stack: {_resumeViewModel.keyWords.selectedTechStack}");
+        condition = _resumeViewModel.keyWords?.condition ?? "and";
+        selectedDomain = _resumeViewModel.keyWords?.selectedDomain ?? "";
+        selectedTechStack = _resumeViewModel.keyWords?.selectedTechStack ?? "";
+        // Update the filtered projects based on the new filter values
+        filteredProjects = _resumeViewModel.FilterProjects(selectedDomain, selectedTechStack, condition);
         Console.WriteLine($"Condition: {condition}");
     }
 }

--- a/src/ViewModels/IResumeViewModel.cs
+++ b/src/ViewModels/IResumeViewModel.cs
@@ -16,7 +16,8 @@ namespace Portfolio.ViewModels
         public List<ConferenceModel>? Conferences { get; set; }
         public List<MentorshipModel>? Mentorships { get; set; }
         public List<ProjectModel>? Projects { get; set; }
-
+        KeyWords keyWords { get; set; }
+        public List<ProjectModel> FilterProjects(string selectedDomain, string selectedTechStack, string condition);
         public Task GetSkills();
         public Task GetBackground();
         public Task GetAccomplishments();

--- a/src/ViewModels/ResumeViewModel.cs
+++ b/src/ViewModels/ResumeViewModel.cs
@@ -18,6 +18,28 @@ namespace Portfolio.ViewModels
         public List<ConferenceModel>? Conferences { get; set; }
         public List<MentorshipModel>? Mentorships { get; set; }
         public List<ProjectModel>? Projects { get; set; }
+        public KeyWords keyWords { get; set; } = new KeyWords();
+        public List<ProjectModel> FilterProjects(string selectedDomain, string selectedTechStack, string condition)
+        {
+            List<ProjectModel> filteredProjects = new List<ProjectModel>();
+
+            foreach (var projectModel in Projects ?? new List<ProjectModel>())
+            {
+                List<string> keyWords = projectModel?.KeyWords?.Split(',').ToList() ?? new List<string>();
+                keyWords = keyWords.Select(keyWord => keyWord.TrimStart()).ToList();
+
+                bool matchesDomain = string.IsNullOrEmpty(selectedDomain) || keyWords.Contains(selectedDomain);
+                bool matchesTechStack = string.IsNullOrEmpty(selectedTechStack) || keyWords.Contains(selectedTechStack);
+
+                if ((condition == "or" && (matchesDomain || matchesTechStack))
+                    || (condition == "and" && matchesDomain && matchesTechStack))
+                {
+                    filteredProjects.Add(projectModel ?? new ProjectModel());
+                }
+            }
+
+            return filteredProjects;
+        }
 
         private HttpClient _httpClient;
 

--- a/src/wwwroot/sample-data/resume.json
+++ b/src/wwwroot/sample-data/resume.json
@@ -269,7 +269,7 @@
         {
             "title": "Project Portfolio Website with Blazor WebAssembly",
             "description": "Open source project to build your project portfolio and host it online.",
-            "repourl": "https://OscarSantosMu/portfolio-blazor-template",
+            "repourl": "https://github.com/OscarSantosMu/portfolio-blazor-template",
             "url": "https://oscarsantosmu.github.io/portfolio-blazor-template",
             "imageurl": "https://raw.githubusercontent.com/OscarSantosMu/portfolio-blazor-template/main/static/img/skills.png",
             "keywords": "C#, .NET, Blazor, Web",


### PR DESCRIPTION
This pull request refactors the filtering logic in the Blazor app's Projects page to adhere more closely to the MVVM pattern and improve separation of concerns. Here's a summary of the changes made:

1. Modified the **IResumeViewModel** interface to include a **KeyWords** property, which represents the filter values for the projects.
2. Modified the **IResumeViewModel** interface to include a **FilterProjects** method signature.
3. Updated the **ResumeViewModel** implementation to include the KeyWords property and initialize it with a new KeyWords object.
4. Updated the **ResumeViewModel** implementation and move filtering logic from **Projects.razor** to **FilterProjects** method.
5. Modified the **Projects.razor** page to bind the **keyWords** object in the **EditForm** component to the **_resumeViewModel.KeyWords property**, enabling two-way data binding.
6. Modified the **Projects.razor** to include **filteredProjects** variable to better reflect its purpose and iterate over this list instead of _resumeViewModel.Projects.
7. Updated the **HandleValidSubmit** method to retrieve the filter values from **_resumeViewModel.KeyWords** instead of **keyWords**.
